### PR TITLE
TEG-262/fetch all pod logs

### DIFF
--- a/diagnostics/k8s_diag.py
+++ b/diagnostics/k8s_diag.py
@@ -261,6 +261,7 @@ class K8sDiags:
                                          f'podlogs-{pod_name}.txt'),
                             'w') as fref:
                         fref.write(ret['stdout'])
+                        logging.info('Copied log: %s/%s', namespace, pod_name)
 
             for item in self.kubedata[namespace]['pods']['items']:
                 for status in item['status']['containerStatuses']:


### PR DESCRIPTION
* Fetch all the logs for every pod in every namespace, instead of just the pods targeted for individual attention.
* get supd override file directly rather than thru jq.